### PR TITLE
fix: DTO presentation / mapping change

### DIFF
--- a/src/main/java/noroff/assignment/moviecharactersapi/controllers/FranchiseController.java
+++ b/src/main/java/noroff/assignment/moviecharactersapi/controllers/FranchiseController.java
@@ -12,9 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.net.URI;
 import java.util.Collection;
-import java.util.List;
 
 @RestController
 @RequestMapping(path = "api/v1/franchises")
@@ -77,9 +75,9 @@ public class FranchiseController {
         return ResponseEntity.ok(characters);
     }
 
-    @PutMapping("{id}/movies") // PUT: localhost:8080/api/v1/franchises/1/movies
-    public ResponseEntity updateMovies(@RequestBody int[] characterIds, @PathVariable int movieId) {
-        franchiseService.updateMovies(movieId, characterIds);
+    @PatchMapping("{id}/movies") // PATCH: localhost:8080/api/v1/franchises/1/movies
+    public ResponseEntity updateMovies(@RequestBody int[] characterIds, @PathVariable int id) {
+        franchiseService.updateMovies(id, characterIds);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/noroff/assignment/moviecharactersapi/controllers/MovieController.java
+++ b/src/main/java/noroff/assignment/moviecharactersapi/controllers/MovieController.java
@@ -59,7 +59,7 @@ public class MovieController {
         return ResponseEntity.noContent().build();
     }
 
-    @PutMapping("{movieId}/characters") // PUT: localhost:8080/api/v1/movies/1/characters
+    @PatchMapping ("{movieId}/characters") // PATCH: localhost:8080/api/v1/movies/1/characters
     public ResponseEntity updateCharacters(@RequestBody int[] characterIds, @PathVariable int movieId) {
         movieService.updateCharacters(movieId, characterIds);
         return ResponseEntity.noContent().build();

--- a/src/main/java/noroff/assignment/moviecharactersapi/mappers/CharacterMapper.java
+++ b/src/main/java/noroff/assignment/moviecharactersapi/mappers/CharacterMapper.java
@@ -3,6 +3,7 @@ package noroff.assignment.moviecharactersapi.mappers;
 import noroff.assignment.moviecharactersapi.models.Character;
 import noroff.assignment.moviecharactersapi.models.Movie;
 import noroff.assignment.moviecharactersapi.models.dtos.CharacterDTO;
+import noroff.assignment.moviecharactersapi.models.dtos.IdDTO;
 import noroff.assignment.moviecharactersapi.services.MovieService;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -28,17 +29,19 @@ public abstract class CharacterMapper {
     public abstract Character characterDtoToCharacter(CharacterDTO characterDTO);
 
     @Named("moviesToIds")
-    Set<Integer> mapMoviesToIds(Set<Movie> source) {
+    Set<IdDTO> mapMoviesToIds(Set<Movie> source) {
         if (source == null)
             return null;
+
         return source.stream()
-                .map(s -> s.getId()).collect(Collectors.toSet());
+                .map(s -> (new IdDTO(s.getId())))
+                        .collect(Collectors.toSet());
     }
 
     @Named("idsToMovies")
-    Set<Movie> mapIdsToMovies(Set<Integer> id) {
+    Set<Movie> mapIdsToMovies(Set<IdDTO> id) {
         return id.stream()
-                .map(i -> movieService.findById(i))
+                .map(i -> movieService.findById(i.getId()))
                 .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/noroff/assignment/moviecharactersapi/mappers/FranchiseMapper.java
+++ b/src/main/java/noroff/assignment/moviecharactersapi/mappers/FranchiseMapper.java
@@ -3,6 +3,7 @@ package noroff.assignment.moviecharactersapi.mappers;
 import noroff.assignment.moviecharactersapi.models.Movie;
 import noroff.assignment.moviecharactersapi.models.Franchise;
 import noroff.assignment.moviecharactersapi.models.dtos.FranchiseDTO;
+import noroff.assignment.moviecharactersapi.models.dtos.IdDTO;
 import noroff.assignment.moviecharactersapi.services.MovieService;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -28,17 +29,18 @@ public abstract class FranchiseMapper {
     public abstract Franchise franchiseDtoToFranchise(FranchiseDTO franchiseDTO);
 
     @Named("moviesToIds")
-    Set<Integer> mapMoviesToIds(Set<Movie> source) {
+    Set<IdDTO> mapMoviesToIds(Set<Movie> source) {
         if (source == null)
             return null;
         return source.stream()
-                .map(s -> s.getId()).collect(Collectors.toSet());
+                .map(s -> (new IdDTO(s.getId())))
+                .collect(Collectors.toSet());
     }
 
     @Named("idsToMovies")
-    Set<Movie> mapIdsToMovies(Set<Integer> id) {
+    Set<Movie> mapIdsToMovies(Set<IdDTO> id) {
         return id.stream()
-                .map(i -> movieService.findById(i))
+                .map(i -> movieService.findById(i.getId()))
                 .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/noroff/assignment/moviecharactersapi/mappers/MovieMapper.java
+++ b/src/main/java/noroff/assignment/moviecharactersapi/mappers/MovieMapper.java
@@ -3,6 +3,7 @@ package noroff.assignment.moviecharactersapi.mappers;
 import noroff.assignment.moviecharactersapi.models.Character;
 import noroff.assignment.moviecharactersapi.models.Franchise;
 import noroff.assignment.moviecharactersapi.models.Movie;
+import noroff.assignment.moviecharactersapi.models.dtos.IdDTO;
 import noroff.assignment.moviecharactersapi.models.dtos.MovieDTO;
 import noroff.assignment.moviecharactersapi.services.CharacterService;
 import noroff.assignment.moviecharactersapi.services.FranchiseService;
@@ -35,17 +36,18 @@ public abstract class MovieMapper {
     public abstract Movie movieDtoToMovie(MovieDTO movieDTO);
 
     @Named("charactersToIds")
-    Set<Integer> mapCharactersToIds(Set<Character> source) {
+    Set<IdDTO> mapCharactersToIds(Set<Character> source) {
         if (source == null)
             return null;
         return source.stream()
-                .map(s -> s.getId()).collect(Collectors.toSet());
+                .map(s -> (new IdDTO(s.getId())))
+                .collect(Collectors.toSet());
     }
 
     @Named("idsToCharacters")
-    Set<Character> mapIdsToProjects(Set<Integer> id) {
+    Set<Character> mapIdsToProjects(Set<IdDTO> id) {
         return id.stream()
-                .map(i -> characterService.findById(i))
+                .map(i -> characterService.findById(i.getId()))
                 .collect(Collectors.toSet());
     }
 

--- a/src/main/java/noroff/assignment/moviecharactersapi/models/dtos/CharacterDTO.java
+++ b/src/main/java/noroff/assignment/moviecharactersapi/models/dtos/CharacterDTO.java
@@ -11,5 +11,5 @@ public class CharacterDTO {
     private String alias;
     private String gender;
     private String photoUrl;
-    private Set<Integer> movies;
+    private Set<IdDTO> movies;
 }

--- a/src/main/java/noroff/assignment/moviecharactersapi/models/dtos/FranchiseDTO.java
+++ b/src/main/java/noroff/assignment/moviecharactersapi/models/dtos/FranchiseDTO.java
@@ -9,5 +9,5 @@ public class FranchiseDTO {
     private int id;
     private String name;
     private String description;
-    private Set<Integer> movies;
+    private Set<IdDTO> movies;
 }

--- a/src/main/java/noroff/assignment/moviecharactersapi/models/dtos/IdDTO.java
+++ b/src/main/java/noroff/assignment/moviecharactersapi/models/dtos/IdDTO.java
@@ -1,0 +1,11 @@
+package noroff.assignment.moviecharactersapi.models.dtos;
+
+import lombok.Data;
+
+@Data
+public class IdDTO {
+    private int id;
+    public IdDTO(int id){
+        this.id=id;
+    }
+}

--- a/src/main/java/noroff/assignment/moviecharactersapi/models/dtos/MovieDTO.java
+++ b/src/main/java/noroff/assignment/moviecharactersapi/models/dtos/MovieDTO.java
@@ -13,6 +13,6 @@ public class MovieDTO {
     private String director;
     private String photoUrl;
     private String trailerUrl;
-    private Set<Integer> characters;
+    private Set<IdDTO> characters;
     private Integer franchise;
 }


### PR DESCRIPTION
Relation arrays included in DTOs now in format {"id":relationId},{"id":relationId} instead of [relationId,relationId]